### PR TITLE
feat: handle non-installed agent error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "find-up": "^5.0.0",
-    "ini": "^1.3.5"
+    "ini": "^1.3.5",
+    "terminal-link": "^2.1.1"
   },
   "devDependencies": {
     "@antfu/eslint-config-ts": "^0.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   find-up: 5.0.0
   ini: 1.3.5
+  terminal-link: 2.1.1
 devDependencies:
   '@antfu/eslint-config-ts': 0.4.3_eslint@7.12.1+typescript@4.0.5
   '@types/ini': 1.3.30
@@ -400,7 +401,6 @@ packages:
   /ansi-escapes/4.3.1:
     dependencies:
       type-fest: 0.11.0
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -1842,7 +1842,6 @@ packages:
     resolution:
       integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
   /has-flag/4.0.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -3490,11 +3489,19 @@ packages:
   /supports-color/7.2.0:
     dependencies:
       has-flag: 4.0.0
-    dev: true
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  /supports-hyperlinks/2.1.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
   /table/5.4.6:
     dependencies:
       ajv: 6.12.6
@@ -3518,6 +3525,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+  /terminal-link/2.1.1:
+    dependencies:
+      ansi-escapes: 4.3.1
+      supports-hyperlinks: 2.1.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
   /test-exclude/6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.2
@@ -3637,7 +3653,6 @@ packages:
     resolution:
       integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   /type-fest/0.11.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -3869,5 +3884,6 @@ specifiers:
   ini: ^1.3.5
   lint-staged: ^10.5.1
   rimraf: ^3.0.2
+  terminal-link: ^2.1.1
   tsup: ^3.7.1
   typescript: ^4.0.5

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -37,3 +37,9 @@ export const LOCKS: Record<string, Agent> = {
   'yarn.lock': 'yarn',
   'package-lock.json': 'npm',
 }
+
+export const INSTALL_PAGE: Record<Agent, string> = {
+  pnpm: 'https://pnpm.js.org/en/installation',
+  yarn: 'https://yarnpkg.com/getting-started/install',
+  npm: 'https://www.npmjs.com/get-npm',
+}

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,10 +1,23 @@
 import path from 'path'
 import findUp from 'find-up'
-import { LOCKS } from './agents'
+import terminalLink from 'terminal-link'
+import { LOCKS, INSTALL_PAGE } from './agents'
 import { getDefaultAgent } from './config'
+import { cmdExists } from './utils'
 
 export async function detect() {
   const result = await findUp(Object.keys(LOCKS))
+  const agent = (result ? LOCKS[path.basename(result)] : '')
 
-  return (result ? LOCKS[path.basename(result)] : '') || await getDefaultAgent()
+  if (!agent)
+    return await getDefaultAgent()
+
+  if (!cmdExists(agent)) {
+    const url = INSTALL_PAGE[agent]
+    const link = terminalLink(url, url)
+    console.log(`Detected ${agent} but it doesn't seem to be installed.\nFollow the instructions to install ${agent}: ${link}`)
+    process.exit(1)
+  }
+
+  return agent
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process'
+
 export function exclude<T>(arr: T[], v: T) {
   const clone = [...arr]
   const index = clone.indexOf(v)
@@ -13,4 +15,14 @@ export function remove<T>(arr: T[], v: T) {
     arr.splice(index, 1)
 
   return arr
+}
+
+export function cmdExists(cmd: string) {
+  try {
+    execSync(`command -v ${cmd}`)
+    return true
+  }
+  catch {
+    return false
+  }
 }


### PR DESCRIPTION
Will be making a few more changes to my fork, but will PR in changes in case you want them.

My end goal is to support `ni --frozen --fallback npm` so that it can be used in arbitrary CI environments (eg. https://github.com/antfu/export-size-action/blob/main/src/size.ts#L29) while also improving user-friendliness via:
- Providing installation instructions if the detected agent is missing
- `--frozen` to fallback to normal install if no lock file is found (this might be unexpected behavior and might be worth adding explicitness for eg. `--frozen=safe`)
- `--fallback` flag to take precedent over `defaultAgent` (for CI envs)